### PR TITLE
Expand A/V server template options

### DIFF
--- a/src/main/java/edu/ucla/library/avpairtree/Config.java
+++ b/src/main/java/edu/ucla/library/avpairtree/Config.java
@@ -67,6 +67,12 @@ public final class Config {
     public static final String ACCESS_URL_PATTERN = "iiif.access.url";
 
     /**
+     * The configuration property for which substitution pattern in iiif.access.url should be the ID; this is 1-based,
+     * not zero-based.
+     */
+    public static final String ACCESS_URL_ID_INDEX = "iiif.access.url.id.index";
+
+    /**
      * The number of workers that should work to do media file conversions.
      */
     public static final String CONVERSION_WORKERS = "conversion.workers";

--- a/src/main/resources/av-pairtree_messages.xml
+++ b/src/main/resources/av-pairtree_messages.xml
@@ -17,5 +17,7 @@
   <entry key="AVPT_010">IIIF access URL created for '{}': {}</entry>
   <entry key="AVPT_011">{} worker starting in: {}</entry>
   <entry key="AVPT_012">{} worker pool size set to '{}' workers</entry>
+  <entry key="AVPT_013">Index for IIIF access URL doesn't correspond to number of substitution patterns: {}</entry>
+  <entry key="AVPT_014">IIIF access URL pattern doesn't contain a supported number of substitution patterns</entry>
 
 </properties>

--- a/src/test/java/edu/ucla/library/avpairtree/verticles/WatcherVerticleTest.java
+++ b/src/test/java/edu/ucla/library/avpairtree/verticles/WatcherVerticleTest.java
@@ -147,7 +147,7 @@ public class WatcherVerticleTest extends AbstractAvPtTest {
             promise.fail(details);
         }
 
-        // final Delete the test final artifact after we've checked it to determine success
+        // Delete the test artifact after we've checked it to determine success
         myContext.vertx().fileSystem().delete(aFileName).onComplete(deletion -> {
             if (deletion.succeeded()) {
                 promise.complete();

--- a/src/test/java/edu/ucla/library/avpairtree/verticles/WatcherVerticleTest.java
+++ b/src/test/java/edu/ucla/library/avpairtree/verticles/WatcherVerticleTest.java
@@ -136,7 +136,7 @@ public class WatcherVerticleTest extends AbstractAvPtTest {
             final AtomicInteger counter = new AtomicInteger(0);
 
             reader.lines().forEach(line -> {
-                if (line.contains(avServer)) {
+                if (line.contains(avServer) && line.contains(".mp4{}")) {
                     counter.incrementAndGet();
                 }
             });
@@ -147,7 +147,7 @@ public class WatcherVerticleTest extends AbstractAvPtTest {
             promise.fail(details);
         }
 
-        // Delete the test artifact after we've checked it to determine success
+        // final Delete the test final artifact after we've checked it to determine success
         myContext.vertx().fileSystem().delete(aFileName).onComplete(deletion -> {
             if (deletion.succeeded()) {
                 promise.complete();

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -20,8 +20,11 @@ audio.codec = aac
 audio.bit.rate = 320000
 audio.channels = 2
 
-# The URL pattern for our streaming A/V server
-iiif.access.url = https://wowza.library.ucla.edu/iiif_av_public/definst/mp4:{}/manifest.mpd
+# The URL pattern for our streaming A/V server; it can have up to three substitution patterns (i.e., "{}")
+iiif.access.url = https://wowza.library.ucla.edu/iiif_av_public/definst/mp4:{}{}
+
+# The 1-based position of the substitution pattern to use for the Pairtree path
+iiif.access.url.id.index = 1
 
 # The number of threads working on media file conversions
 conversion.workers = 2


### PR DESCRIPTION
This provides a way to create a generic A/V server URL that another process (in
our case, Fester) can append information onto. This provides a way for Fester
to create a choice of video streams, rather than hardcode just one stream (mpd,
for instance).