### PR TITLE
Parameterize avpt_data_pipeline.sh with env var for Metagetter JAR path

### DIFF
--- a/src/main/scripts/README.md
+++ b/src/main/scripts/README.md
@@ -25,6 +25,7 @@ Environment variable|Description
 ---|---
 AVPTDP_INPUT_DIRECTORY|directory where A/V Pairtree puts .out files; this is the input directory for the pipeline (and thus, for Metagetter)
 AVPTDP_FESTERIZE_OUTPUT_DIRECTORY|directory where Festerize puts .csv files
+AVPTDP_METAGETTER_JAR_PATH|path to the Metagetter JAR
 AVPTDP_METAGETTER_MEDIA_DIRECTORY|directory where Metagetter will search for A/V media files
 AVPTDP_METAGETTER_OUTPUT_DIRECTORY|directory where Metagetter puts .out files (which are then renamed as .csv); this is the input directory for Festerize
 AVPTDP_SLACK_WEBHOOK_URL|URL of the webhook for posting to Slack
@@ -45,6 +46,7 @@ For example:
 
 export AVPTDP_INPUT_DIRECTORY="avpt_output/"
 export AVPTDP_FESTERIZE_OUTPUT_DIRECTORY="festerize_output/"
+export AVPTDP_METAGETTER_JAR_PATH="target/build-artifact/services-metagetter-0.0.1-SNAPSHOT.jar"
 export AVPTDP_METAGETTER_MEDIA_DIRECTORY="metagetter_media/"
 export AVPTDP_METAGETTER_OUTPUT_DIRECTORY="metagetter_output/"
 export AVPTDP_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/0123456789"

--- a/src/main/scripts/avpt_data_pipeline.sh
+++ b/src/main/scripts/avpt_data_pipeline.sh
@@ -3,7 +3,7 @@
 function get_av_metadata {
     # Runs the CSV at the path provided via $1 through services-metagetter and outputs the path of the result CSV
     2>/dev/null 1>&2 \
-    java -jar UCLALibrary/services-metagetter/target/build-artifact/services-metagetter-0.0.1-SNAPSHOT.jar \
+    java -jar ${AVPTDP_METAGETTER_JAR_PATH} \
         $1 ${AVPTDP_METAGETTER_MEDIA_DIRECTORY} `which ffprobe` ${AVPTDP_METAGETTER_OUTPUT_DIRECTORY} &&
     echo `strip_trailing_slash ${AVPTDP_METAGETTER_OUTPUT_DIRECTORY}`/`basename $1`
 }
@@ -64,6 +64,10 @@ then
 elif [ -z "${AVPTDP_FESTERIZE_OUTPUT_DIRECTORY}" ]
 then
     echo "The env var AVPTDP_FESTERIZE_OUTPUT_DIRECTORY must be set."
+    exit 1
+elif [ -z "${AVPTDP_METAGETTER_JAR_PATH}" ]
+then
+    echo "The env var AVPTDP_METAGETTER_JAR_PATH must be set."
     exit 1
 elif [ -z "${AVPTDP_METAGETTER_MEDIA_DIRECTORY}" ]
 then


### PR DESCRIPTION
Removes the hard-coded JAR path in favor of an env var.