### PR TITLE
[SERV-126] Allow audiowaveform processes to exit

### DIFF
--- a/src/main/java/edu/ucla/library/avpairtree/Config.java
+++ b/src/main/java/edu/ucla/library/avpairtree/Config.java
@@ -78,6 +78,11 @@ public final class Config {
     public static final String CONVERSION_WORKERS = "conversion.workers";
 
     /**
+     * The number of workers that should work to do audiowaveform generation.
+     */
+    public static final String WAVEFORM_WORKERS = "waveform.workers";
+
+    /**
      * The environment variable for the S3 bucket for audio waveforms.
      */
     public static final String AUDIOWAVEFORM_S3_BUCKET = "AUDIOWAVEFORM_S3_BUCKET";

--- a/src/main/java/edu/ucla/library/avpairtree/verticles/WatcherVerticle.java
+++ b/src/main/java/edu/ucla/library/avpairtree/verticles/WatcherVerticle.java
@@ -200,8 +200,12 @@ public class WatcherVerticle extends AbstractVerticle {
                             if (aCsvItemMap.containsKey(ark)) {
                                 row[index] = constructAccessURL(csvItem);
                             } else {
-                                // Don't overwrite what may already be there (e.g. in the case of images)
-                                row[index] = originalRow.get(index + 1);
+                                if (originalAccessUrlIndex != -1) {
+                                    // Don't overwrite what was already there (e.g. in the case of images)
+                                    row[index] = originalRow.get(index + 1);
+                                } else {
+                                    row[index] = "";
+                                }
                             }
                         } else if (waveformIndex == index) {
                             row[index] = aWaveformMap.getString(ark, "");

--- a/src/main/java/edu/ucla/library/avpairtree/verticles/WaveformVerticle.java
+++ b/src/main/java/edu/ucla/library/avpairtree/verticles/WaveformVerticle.java
@@ -61,6 +61,8 @@ public final class WaveformVerticle extends AbstractVerticle {
         final String cmdline = String.join(SPACE, cmd);
         final String configErrorMsg;
 
+        LOGGER.debug(MessageCodes.AVPT_011, WaveformVerticle.class.getSimpleName(), Thread.currentThread().getName());
+
         // Make sure that audiowaveform is installed on the system
 
         try {

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -28,3 +28,6 @@ iiif.access.url.id.index = 1
 
 # The number of threads working on media file conversions
 conversion.workers = 2
+
+# The number of threads working on audiowaveform generation
+waveform.workers = 2


### PR DESCRIPTION
While running A/V Pairtree in production for the first time, I observed that the `audiowaveform` processes were getting stuck in the "interruptible sleep" state. I determined that they were simply waiting for I/O to complete (i.e., for their output to be read by the parent process); from [the docs](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Process.html):

> Because some native platforms only provide limited buffer size for standard input and output streams, failure to promptly write the input stream or read the output stream of the process may cause the process to block, or even deadlock.

I guess this is why. Interestingly, the automated tests didn't catch this -- anyone have an idea why?

Anyway, I've manually tested this change locally and on our "prod" machine, and can confirm that it actually works now.

Also, the debug logging is a bit more verbose now (stderr provides interesting stats about the audiowaveform conversion).