### PR TITLE
Increase CPU utilization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,7 +70,6 @@ The properties and default values for an av-pairtree configuration file are as f
 | audio.encoding.threads | The number of threads to use in audio encoding | 0 (all available) |
 | iiif.access.url | The URL pattern into which to insert the Pairtree path | N/A |
 | conversion.workers | The number of cores to use for audio file conversion | 2 |
-| pairtree.workers | The number of cores to use for pairtree insertion | 2 |
 | waveform.workers | The number of cores to use for audiowaveform generation | 2 |
 
 ## Documentation

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,7 @@ The properties and default values for an av-pairtree configuration file are as f
 | audio.codec | The audio codec to use inside the encoding wrapper | aac |
 | audio.bit.rate | The bit rate used to encoding the audio stream | 128000 |
 | audio.channels | The number of channels in the audio stream | 2 |
+| audio.encoding.threads | The number of threads to use in audio encoding | 0 (all available) |
 | iiif.access.url | The URL pattern into which to insert the Pairtree path | N/A |
 | conversion.workers | The number of cores to use for audio file conversion | 2 |
 | waveform.workers | The number of cores to use for audiowaveform generation | 2 |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,6 +69,7 @@ The properties and default values for an av-pairtree configuration file are as f
 | audio.channels | The number of channels in the audio stream | 2 |
 | iiif.access.url | The URL pattern into which to insert the Pairtree path | N/A |
 | conversion.workers | The number of cores to use for audio file conversion | 2 |
+| waveform.workers | The number of cores to use for audiowaveform generation | 2 |
 
 ## Documentation
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,6 +70,7 @@ The properties and default values for an av-pairtree configuration file are as f
 | audio.encoding.threads | The number of threads to use in audio encoding | 0 (all available) |
 | iiif.access.url | The URL pattern into which to insert the Pairtree path | N/A |
 | conversion.workers | The number of cores to use for audio file conversion | 2 |
+| pairtree.workers | The number of cores to use for pairtree insertion | 2 |
 | waveform.workers | The number of cores to use for audiowaveform generation | 2 |
 
 ## Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@
                 <id>test-vertx-startup</id>
                 <phase>test</phase>
                 <goals>
-                  <goal>debug</goal>
+                  <goal>run</goal>
                 </goals>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@
                 <id>test-vertx-startup</id>
                 <phase>test</phase>
                 <goals>
-                  <goal>run</goal>
+                  <goal>debug</goal>
                 </goals>
               </execution>
             </executions>

--- a/src/main/java/edu/ucla/library/avpairtree/Config.java
+++ b/src/main/java/edu/ucla/library/avpairtree/Config.java
@@ -62,6 +62,11 @@ public final class Config {
     public static final String ENCODING_FORMAT = "audio.encoding.format";
 
     /**
+     * The configuration property for the number of threads to use in FFmpeg encoding.
+     */
+    public static final String ENCODING_THREADS = "audio.encoding.threads";
+
+    /**
      * A configuration property for the pattern for creating IIIF access URLs.
      */
     public static final String ACCESS_URL_PATTERN = "iiif.access.url";

--- a/src/main/java/edu/ucla/library/avpairtree/Config.java
+++ b/src/main/java/edu/ucla/library/avpairtree/Config.java
@@ -83,6 +83,11 @@ public final class Config {
     public static final String CONVERSION_WORKERS = "conversion.workers";
 
     /**
+     * The number of workers that should work to do pairtree insertions.
+     */
+    public static final String PAIRTREE_WORKERS = "pairtree.workers";
+
+    /**
      * The number of workers that should work to do audiowaveform generation.
      */
     public static final String WAVEFORM_WORKERS = "waveform.workers";

--- a/src/main/java/edu/ucla/library/avpairtree/Config.java
+++ b/src/main/java/edu/ucla/library/avpairtree/Config.java
@@ -83,11 +83,6 @@ public final class Config {
     public static final String CONVERSION_WORKERS = "conversion.workers";
 
     /**
-     * The number of workers that should work to do pairtree insertions.
-     */
-    public static final String PAIRTREE_WORKERS = "pairtree.workers";
-
-    /**
      * The number of workers that should work to do audiowaveform generation.
      */
     public static final String WAVEFORM_WORKERS = "waveform.workers";

--- a/src/main/java/edu/ucla/library/avpairtree/verticles/ConverterVerticle.java
+++ b/src/main/java/edu/ucla/library/avpairtree/verticles/ConverterVerticle.java
@@ -93,6 +93,7 @@ public class ConverterVerticle extends AbstractVerticle {
 
                 encoding.setOutputFormat(outputFormat);
                 encoding.setAudioAttributes(audio);
+                encoding.setEncodingThreads(config.getInteger(Config.ENCODING_THREADS));
 
                 encoder.encode(new MultimediaObject(inputFilePath.toFile()), outputFilePath.toFile(), encoding);
                 csvItem.setFilePath(outputFilePath.toAbsolutePath().toString());

--- a/src/main/java/edu/ucla/library/avpairtree/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/avpairtree/verticles/MainVerticle.java
@@ -130,7 +130,7 @@ public class MainVerticle extends AbstractVerticle {
                     final List<Future> futures = new ArrayList<>();
 
                     futures.add(deployVerticle(new WatcherVerticle(), aConfig));
-                    futures.add(deployVerticle(new PairtreeVerticle(), aConfig));
+                    futures.add(deployVerticle(new PairtreeVerticle(), aConfig.copy().put(WORKER, true)));
                     futures.add(deployVerticle(new ConverterVerticle(), aConfig.copy().put(WORKER, true)));
                     futures.add(deployVerticle(new WaveformVerticle(), aConfig.copy().put(WORKER, true)));
 
@@ -171,6 +171,8 @@ public class MainVerticle extends AbstractVerticle {
 
             if (ConverterVerticle.class.equals(verticleClass)) {
                 nWorkerInstances = aConfig.getInteger(Config.CONVERSION_WORKERS, DEFAULT_WORKER_COUNT);
+            } else if (PairtreeVerticle.class.equals(verticleClass)) {
+                nWorkerInstances = aConfig.getInteger(Config.PAIRTREE_WORKERS, DEFAULT_WORKER_COUNT);
             } else if (WaveformVerticle.class.equals(verticleClass)) {
                 nWorkerInstances = aConfig.getInteger(Config.WAVEFORM_WORKERS, DEFAULT_WORKER_COUNT);
             } else {

--- a/src/main/java/edu/ucla/library/avpairtree/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/avpairtree/verticles/MainVerticle.java
@@ -130,7 +130,7 @@ public class MainVerticle extends AbstractVerticle {
                     final List<Future> futures = new ArrayList<>();
 
                     futures.add(deployVerticle(new WatcherVerticle(), aConfig));
-                    futures.add(deployVerticle(new PairtreeVerticle(), aConfig.copy().put(WORKER, true)));
+                    futures.add(deployVerticle(new PairtreeVerticle(), aConfig));
                     futures.add(deployVerticle(new ConverterVerticle(), aConfig.copy().put(WORKER, true)));
                     futures.add(deployVerticle(new WaveformVerticle(), aConfig.copy().put(WORKER, true)));
 
@@ -171,8 +171,6 @@ public class MainVerticle extends AbstractVerticle {
 
             if (ConverterVerticle.class.equals(verticleClass)) {
                 nWorkerInstances = aConfig.getInteger(Config.CONVERSION_WORKERS, DEFAULT_WORKER_COUNT);
-            } else if (PairtreeVerticle.class.equals(verticleClass)) {
-                nWorkerInstances = aConfig.getInteger(Config.PAIRTREE_WORKERS, DEFAULT_WORKER_COUNT);
             } else if (WaveformVerticle.class.equals(verticleClass)) {
                 nWorkerInstances = aConfig.getInteger(Config.WAVEFORM_WORKERS, DEFAULT_WORKER_COUNT);
             } else {

--- a/src/main/resources/av-pairtree_messages.xml
+++ b/src/main/resources/av-pairtree_messages.xml
@@ -17,7 +17,7 @@
   <entry key="AVPT_009">Media file asssociated with '{}' was successfully processed</entry>
   <entry key="AVPT_010">IIIF access URL created for '{}': {}</entry>
   <entry key="AVPT_011">{} worker starting in: {}</entry>
-  <entry key="AVPT_012">{} worker pool size set to '{}' workers</entry>
+  <entry key="AVPT_012">Deploying {} instances of worker '{}'</entry>
   <entry key="AVPT_013">Index for IIIF access URL doesn't correspond to number of substitution patterns: {}</entry>
   <entry key="AVPT_014">IIIF access URL pattern doesn't contain a supported number of substitution patterns</entry>
   <entry key="AVPT_015">Command '{}' exited with code {}. Output: {}</entry>

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -20,14 +20,17 @@ audio.codec = aac
 audio.bit.rate = 320000
 audio.channels = 2
 
+# Set to 0 to use all available cores
+audio.encoding.threads = 0
+
 # The URL pattern for our streaming A/V server; it can have up to three substitution patterns (i.e., "{}")
 iiif.access.url = https://wowza.library.ucla.edu/iiif_av_public/definst/mp4:{}{}
 
 # The 1-based position of the substitution pattern to use for the Pairtree path
 iiif.access.url.id.index = 1
 
-# The number of threads working on media file conversions
+# The number of cores to use for audio file conversion
 conversion.workers = 2
 
-# The number of threads working on audiowaveform generation
+# The number of cores to use for audiowaveform generation
 waveform.workers = 2

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -32,8 +32,5 @@ iiif.access.url.id.index = 1
 # The number of cores to use for audio file conversion
 conversion.workers = 2
 
-# The number of cores to use for pairtree insertion
-pairtree.workers = 2
-
 # The number of cores to use for audiowaveform generation
 waveform.workers = 2

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -32,5 +32,8 @@ iiif.access.url.id.index = 1
 # The number of cores to use for audio file conversion
 conversion.workers = 2
 
+# The number of cores to use for pairtree insertion
+pairtree.workers = 2
+
 # The number of cores to use for audiowaveform generation
 waveform.workers = 2


### PR DESCRIPTION
Before:
![avpt_htop_before](https://user-images.githubusercontent.com/6744471/124851529-9337f980-df57-11eb-9637-bb830c1e498f.png)

After:
![avpt_htop_after](https://user-images.githubusercontent.com/6744471/124851545-9c28cb00-df57-11eb-89e3-2b868cfd8b95.png)

These screenshots were taken within the first 5 minutes of passing `soul.csv` to AVPT; in "after", the load average increased to over "15" near the end of the process. It used to take around 90 minutes to process the CSV, now it takes around **20 minutes** 🤯 ❗

This is admittedly a very rough measurement, but all signs point to much better performance.