### PR TITLE
Add newer Sonatype repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,18 @@
       </build>
     </profile>
   </profiles>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>


### PR DESCRIPTION
One (hopefully) more deployment fix. We need to use a newer OSS Sonatype deployment repository than what's configured in the parent project because the UCLALibrary org created their account more recently than the parent project's "org" and newer accounts get a newer repository to use. This worked from my local machine so it _should_ work from GitHub Actions.