### PR TITLE
[SERV-255] Use Festerize in strict mode, for non-zero exit codes on errors

### DIFF
--- a/src/main/scripts/README.md
+++ b/src/main/scripts/README.md
@@ -15,7 +15,7 @@ Dependencies:
 - ffmpeg
 - [inotifywait](https://github.com/inotify-tools/inotify-tools)
 - [UCLALibrary/services-metagetter](https://github.com/UCLALibrary/services-metagetter)
-- [UCLALibrary/festerize](https://github.com/UCLALibrary/festerize)
+- [UCLALibrary/festerize](https://github.com/UCLALibrary/festerize) 0.4.0 or greater
 
 ### Usage
 

--- a/src/main/scripts/avpt_data_pipeline.sh
+++ b/src/main/scripts/avpt_data_pipeline.sh
@@ -22,7 +22,7 @@ function festerize_ {
     # outputs the path of the result CSV
     read -r csv_filename &&
     2>/dev/null 1>&2 \
-    festerize --iiif-api-version 3 --server "$1" --out "${AVPTDP_FESTERIZE_OUTPUT_DIRECTORY}" "${csv_filename}" <<< "y"
+    festerize --strict-mode --iiif-api-version 3 --server "$1" --out "${AVPTDP_FESTERIZE_OUTPUT_DIRECTORY}" "${csv_filename}" <<< "y"
     if [[ $? -eq 0 ]]
     then
         echo $(strip_trailing_slash "${AVPTDP_FESTERIZE_OUTPUT_DIRECTORY}")/$(basename "${csv_filename}")


### PR DESCRIPTION
This will make the script behave properly e.g. when Fester returns an error due to a malformed CSV (missing column, etc.).